### PR TITLE
some maybe-copy-paste text errors

### DIFF
--- a/src/pages/ChangePasswordPage.js
+++ b/src/pages/ChangePasswordPage.js
@@ -7,7 +7,7 @@ import InputField from '../components/InputField';
 import { useApi } from '../contexts/ApiProvider';
 import { useFlash } from '../contexts/FlashProvider';
 
-export default function EditUserPage() {
+export default function ChangePasswordPage() {
   const [formErrors, setFormErrors] = useState({});
   const oldPasswordField = useRef();
   const passwordField = useRef();

--- a/src/pages/ResetPage.js
+++ b/src/pages/ResetPage.js
@@ -7,7 +7,7 @@ import InputField from '../components/InputField';
 import { useApi } from '../contexts/ApiProvider';
 import { useFlash } from '../contexts/FlashProvider';
 
-export default function EditUserPage() {
+export default function ResetPage() {
   const [formErrors, setFormErrors] = useState({});
   const passwordField = useRef();
   const password2Field = useRef();


### PR DESCRIPTION
the exported finction name might have some input errors, pls consider the change. 

And beyond that, **ANOTHER ISSUE found here** - might should be dealed with either in this repo OR in api repo: 
Line 42 of `EditUserPage.js`, which says `setFormErrors(response.body.errors.json);`
When I input an existed email address in user profile, which will trigger a 'duplicate entry' error from backend - is obviously correct. But the response from backend (python part) is not compatible with this `setFormErrors(response.body.errors.json);` and trigger an js error in browser console, pls consider mitigate that.