### PR TITLE
Add tz support to Post.test.js

### DIFF
--- a/src/components/Post.test.js
+++ b/src/components/Post.test.js
@@ -3,10 +3,11 @@ import { BrowserRouter } from 'react-router-dom';
 import Post from './Post';
 
 test('it renders all the components of the post', () => {
+  const postDateUTC = '2022-01-01T00:00:00.000Z';
   const post = {
     text: 'hello',
     author: {username: 'susan', avatar_url: 'https://example.com/avatar/susan'},
-    timestamp: '2022-01-01T00:00:00.000Z',
+    timestamp: postDateUTC,
   };
 
   render(
@@ -27,5 +28,5 @@ test('it renders all the components of the post', () => {
   expect(avatar).toHaveAttribute('src', 'https://example.com/avatar/susan&s=48');
   expect(timestamp).toBeInTheDocument();
   expect(timestamp).toHaveAttribute(
-    'title', 'Sat Jan 01 2022 00:00:00 GMT+0000 (Greenwich Mean Time)');
-});
+    'title', new Date(postDateUTC).toString());
+}); 


### PR DESCRIPTION
In `TimeAgo.js`, we have

https://github.com/miguelgrinberg/react-microblog/blob/93916501663d2f1ff11f5361442830a794e157a3/src/components/TimeAgo.js#L46-L48

so we are setting the title to a tz-aware date string, dependent upon the client tz (and upon the tz of the local system running tests). Tests in `Post.test.js` may fail since the expected date string is hard-coded with a fixed timezone:

https://github.com/miguelgrinberg/react-microblog/blob/93916501663d2f1ff11f5361442830a794e157a3/src/components/Post.test.js#L29-L30

E.g., in my case, I get:

```
  Expected the element to have attribute:
    title="Sat Jan 01 2022 00:00:00 GMT+0000 (Greenwich Mean Time)"
  Received:
    title="Sat Jan 01 2022 01:00:00 GMT+0100 (Central European Standard Time)"
```

This PR proposes a quick approach to make things tz-aware.